### PR TITLE
Add basic judge service and endpoint

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -17,7 +17,8 @@
         "morgan": "^1.10.0",
         "nodemon": "^2.0.20",
         "swagger-jsdoc": "^6.2.5",
-        "swagger-ui-express": "^4.6.0"
+        "swagger-ui-express": "^4.6.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "eslint": "^8.23.1",
@@ -615,6 +616,15 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -4947,10 +4957,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5650,6 +5659,14 @@
         "@aws-sdk/util-middleware": "3.198.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -8784,10 +8801,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "validator": {
       "version": "13.7.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -40,5 +40,10 @@
       "prettier --write"
     ],
     "*.{css,html,scss}": "prettier --write"
+  },
+  "nodemonConfig": {
+    "ignore": [
+      "temp-judge/*"
+    ]
   }
 }

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -24,7 +24,8 @@
     "morgan": "^1.10.0",
     "nodemon": "^2.0.20",
     "swagger-jsdoc": "^6.2.5",
-    "swagger-ui-express": "^4.6.0"
+    "swagger-ui-express": "^4.6.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "eslint": "^8.23.1",

--- a/src/backend/src/routes/judge.js
+++ b/src/backend/src/routes/judge.js
@@ -1,9 +1,38 @@
 import { Router } from 'express';
+import { Problems } from '../database/mongoose.js';
+
+import judge from '../services/judge/index.js';
 
 const router = Router();
 
-router.get('/', (_req, res) => {
-  res.send('GET /judge works');
+router.post('/:id', async (req, res) => {
+  const { id } = req.params;
+  const { code, language } = req.body;
+  try {
+    const problem = await Problems.findById(id);
+    if (!problem) {
+      res.status(404).send({ message: `Problem ${id} not found.` });
+    }
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const { input, output } of problem.test_cases) {
+      const judgeResult = await judge({
+        language,
+        code,
+        input,
+        output,
+        timeout: problem.time_limit,
+      });
+      if (!judgeResult) {
+        res.status(200).send('A test case failed.');
+        return;
+      }
+    }
+    res.status(200).send('All test cases passed!');
+  } catch (e) {
+    res.status(500).send({
+      message: e,
+    });
+  }
 });
 
 export default router;

--- a/src/backend/src/routes/judge.js
+++ b/src/backend/src/routes/judge.js
@@ -5,13 +5,48 @@ import judge from '../services/judge/index.js';
 
 const router = Router();
 
-router.post('/:id', async (req, res) => {
-  const { id } = req.params;
+/**
+ * @swagger
+ * /judge/{_id}:
+ *   post:
+ *     tags:
+ *        - judge
+ *     summary: Judges code against a problem's test cases
+ *     description: Judges code against a problem's test cases
+ *     parameters:
+ *       - name: _id
+ *         in: path
+ *         description: Problem id to judge
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - code
+ *               - language
+ *             properties:
+ *               code:
+ *                 type: string
+ *               language:
+ *                 type: string
+ *     responses:
+ *       '200':
+ *         description: If code passes all cases then All test cases passed! otherwise A test case failed.
+ *       '500':
+ *         description: Internal Failure
+ *
+ */
+router.post('/:_id', async (req, res) => {
+  const { _id } = req.params;
   const { code, language } = req.body;
   try {
-    const problem = await Problems.findById(id);
+    const problem = await Problems.findById(_id);
     if (!problem) {
-      res.status(404).send({ message: `Problem ${id} not found.` });
+      res.status(404).send({ message: `Problem ${_id} not found.` });
     }
     // eslint-disable-next-line no-restricted-syntax
     for await (const { input, output } of problem.test_cases) {

--- a/src/backend/src/services/judge/index.js
+++ b/src/backend/src/services/judge/index.js
@@ -1,44 +1,67 @@
 import { exec } from 'child_process';
-import { writeFile, unlink } from 'fs';
+import { writeFile, unlink, access, constants, mkdir } from 'fs';
 
-import { generateCommand, generatePath } from './language-generators.js';
+import {
+  JUDGE_DIR,
+  generateCommand,
+  generatePath,
+} from './language-generators.js';
+
+const ensureJudgeDirExists = () =>
+  new Promise((resolve, reject) => {
+    access(JUDGE_DIR, constants.F_OK, (accessFailed) => {
+      if (accessFailed) {
+        mkdir(JUDGE_DIR, (err) => {
+          if (err) {
+            reject(err);
+          }
+          resolve();
+        });
+      }
+      resolve();
+    });
+  });
 
 export default ({ language, code, input, output, timeout }) =>
   new Promise((resolve, reject) => {
-    const codePath = generatePath(language);
-    writeFile(codePath, code, (err) => {
-      if (err) {
-        reject(err);
-      }
-    });
+    ensureJudgeDirExists()
+      .then(() => {
+        const codePath = generatePath(language);
+        writeFile(codePath, code, (err) => {
+          if (err) {
+            reject(err);
+          }
+        });
 
-    const cmd = generateCommand(language, codePath);
-    if (!cmd) {
-      reject(new Error(`Unsupported Language: ${language}`));
-    }
+        const cmd = generateCommand(language, codePath);
+        if (!cmd) {
+          reject(new Error(`Unsupported Language: ${language}`));
+        }
 
-    const child = exec(cmd, { timeout }, (err, stdout, stderr) => {
-      if (stderr) {
-        reject(stderr);
-      }
-      if (err) {
-        reject(err);
-      }
-      if (stdout) {
-        resolve(stdout === output);
-      }
-    });
+        const child = exec(cmd, { timeout }, (err, stdout, stderr) => {
+          if (stderr) {
+            reject(stderr);
+          }
+          if (err) {
+            reject(err);
+          }
+          if (stdout) {
+            resolve(stdout === output);
+          }
+        });
 
-    child.stdout.on('data', (stdout) => {
-      unlink(codePath, (err) => {
-        reject(err);
-      });
-      resolve(stdout === output);
-    });
+        child.stdout.on('data', (stdout) => {
+          unlink(codePath, (err) => {
+            reject(err);
+          });
+          resolve(stdout === output);
+        });
 
-    child.stdin.setEncoding('utf-8');
-    // This option is helpful for debugging:
-    // child.stdout.pipe(process.stdout);
-    child.stdin.write(input);
-    child.stdin.end();
+        child.stdin.setEncoding('utf-8');
+        // This option is helpful for debugging:
+        // child.stdout.pipe(process.stdout);
+        child.stdin.write(input);
+        child.stdin.end();
+      })
+      .catch((err) => reject(err));
   });

--- a/src/backend/src/services/judge/index.js
+++ b/src/backend/src/services/judge/index.js
@@ -1,0 +1,44 @@
+import { exec } from 'child_process';
+import { writeFile, unlink } from 'fs';
+
+import { generateCommand, generatePath } from './language-generators.js';
+
+export default ({ language, code, input, output, timeout }) =>
+  new Promise((resolve, reject) => {
+    const codePath = generatePath(language);
+    writeFile(codePath, code, (err) => {
+      if (err) {
+        reject(err);
+      }
+    });
+
+    const cmd = generateCommand(language, codePath);
+    if (!cmd) {
+      reject(new Error(`Unsupported Language: ${language}`));
+    }
+
+    const child = exec(cmd, { timeout }, (err, stdout, stderr) => {
+      if (stderr) {
+        reject(stderr);
+      }
+      if (err) {
+        reject(err);
+      }
+      if (stdout) {
+        resolve(stdout === output);
+      }
+    });
+
+    child.stdout.on('data', (stdout) => {
+      unlink(codePath, (err) => {
+        reject(err);
+      });
+      resolve(stdout === output);
+    });
+
+    child.stdin.setEncoding('utf-8');
+    // This option is helpful for debugging:
+    // child.stdout.pipe(process.stdout);
+    child.stdin.write(input);
+    child.stdin.end();
+  });

--- a/src/backend/src/services/judge/language-generators.js
+++ b/src/backend/src/services/judge/language-generators.js
@@ -1,0 +1,15 @@
+import { v4 } from 'uuid';
+import path from 'path';
+
+export const JUDGE_DIR = 'temp-judge';
+const FILE_START = 'TEMP-CODE-';
+const PATH_START = path.join(JUDGE_DIR, FILE_START);
+
+const commands = Object.freeze({
+  js: `node `,
+});
+
+export const generatePath = (language) => `${PATH_START + v4()}.${language}`;
+
+export const generateCommand = (language, filePath) =>
+  commands[language] + filePath;


### PR DESCRIPTION
A simple judge supporting `Node.js` by compiling and running on the local file system and handling inputs/outputs through `stdin` and `stdout`.

# Issues
Closes #22  and #23 

# Sample Usage

## Example Problem
![image](https://user-images.githubusercontent.com/32617102/201748798-84979e5d-49a6-47d7-a3be-5a8919b13a4a.png)

## Correct Solution Example

### Input Code

This uses the input from the problem to demonstrate `stdin` functionality.
```
import readline from 'readline';
const stdin = readline.createInterface({
  input: process.stdin,
  output: process.stdout,
});
stdin.question('', (input) => {
  console.log(input);
  stdin.close();
});
```

### Example API Response

![image](https://user-images.githubusercontent.com/32617102/201749080-925d4f4a-d5fe-48ea-b1ec-9ff4735293cc.png)

## Incorrect Solution Example

### Input Code

```
console.log('goodbye world');
```

### Example API Response

![image](https://user-images.githubusercontent.com/32617102/201749881-78b23ab2-bf78-4484-8a1a-7d77afff384c.png)

