### PR TITLE
[BE][Lobby][Bug] Fix bug where clients were not removed from prev games

### DIFF
--- a/src/backend/src/services/ws/index.js
+++ b/src/backend/src/services/ws/index.js
@@ -307,27 +307,16 @@ export default class WebSocketManager {
   }
 
   leaveGame(ws, token) {
-    const decodedToken = decodeToken(token);
-    let gameToRemove;
-    this.games.forEach((game, gameID) => {
-      /* eslint-disable no-param-reassign */
-      const updatedClients = game.clientIds.filter(
-        (clientId) => clientId !== decodedToken.email
-      );
+    const { email } = decodeToken(token);
+    const gameID = this.clients.get(email).game;
+    if (!gameID) return;
+    const game = this.games.get(gameID);
+    game.clientIds = game.clientIds.filter((clientId) => clientId !== email);
 
-      if (updatedClients.length < game.clientIds.length) {
-        game.clientIds = updatedClients;
-        if (game.clientIds.length) {
-          this.sendUpdatedPlayers(game);
-        } else {
-          gameToRemove = gameID;
-        }
-      }
-    });
-    const client = this.clients.get(decodedToken.email);
-    client.gameID = null;
-    if (gameToRemove) {
-      this.games.delete(gameToRemove);
+    if (game.clientIds.length) {
+      this.sendUpdatedPlayers(game);
+    } else {
+      this.games.delete(gameID);
     }
   }
 }

--- a/src/backend/src/services/ws/index.js
+++ b/src/backend/src/services/ws/index.js
@@ -311,13 +311,17 @@ export default class WebSocketManager {
     let gameToRemove;
     this.games.forEach((game, gameID) => {
       /* eslint-disable no-param-reassign */
-      game.clientIds = game.clientIds.filter(
+      const updatedClients = game.clientIds.filter(
         (clientId) => clientId !== decodedToken.email
       );
-      if (game.clientIds.length) {
-        this.sendUpdatedPlayers(game);
-      } else {
-        gameToRemove = gameID;
+
+      if (updatedClients.length < game.clientIds.length) {
+        game.clientIds = updatedClients;
+        if (game.clientIds.length) {
+          this.sendUpdatedPlayers(game);
+        } else {
+          gameToRemove = gameID;
+        }
       }
     });
     const client = this.clients.get(decodedToken.email);

--- a/src/backend/src/services/ws/index.js
+++ b/src/backend/src/services/ws/index.js
@@ -308,14 +308,22 @@ export default class WebSocketManager {
 
   leaveGame(ws, token) {
     const decodedToken = decodeToken(token);
-    this.games.forEach((value) => {
+    let gameToRemove;
+    this.games.forEach((game, gameID) => {
       /* eslint-disable no-param-reassign */
-      value.clientIds = value.clientIds.filter(
+      game.clientIds = game.clientIds.filter(
         (clientId) => clientId !== decodedToken.email
       );
-      this.sendUpdatedPlayers(value);
+      if (game.clientIds.length) {
+        this.sendUpdatedPlayers(game);
+      } else {
+        gameToRemove = gameID;
+      }
     });
     const client = this.clients.get(decodedToken.email);
     client.gameID = null;
+    if (gameToRemove) {
+      this.games.delete(gameToRemove);
+    }
   }
 }

--- a/src/backend/src/services/ws/index.js
+++ b/src/backend/src/services/ws/index.js
@@ -79,18 +79,17 @@ export default class WebSocketManager {
     this.sendUpdatedPlayers(game);
   }
 
-  disconnectClient(ws, decodedToken) {
-    if (
-      this.clients.has(decodedToken.email) &&
-      this.clients.get(decodedToken.email).ws !== ws
-    ) {
-      this.clients.get(decodedToken.email).ws.send(
+  disconnectClient(ws, token) {
+    const { email } = decodeToken(token);
+    if (this.clients.has(email) && this.clients.get(email).ws !== ws) {
+      this.clients.get(email).ws.send(
         JSON.stringify({
           method: Events.DISCONNECT,
           message:
             'Another user from the same email has connected, Disconnected from lobby',
         })
       );
+      this.leaveGame(ws, token);
     }
   }
 


### PR DESCRIPTION
### Context

Due to the timer feature clients lose games if problem are not completed in the desired time. When a player closes the tab or joins a new game, their old game is still in progress. Due to this the clients received the 'You Lost' message from their previous games that they left.

### Changes

- Disconnect function expected a decodedToken but the regular token was passed
- Client is now removed from the previous game
- Removes game if no clients are connected
- Removes unnecessary messages to all connected clients of codechamp (rewrote leaveGame)

### Tests

Game history as clients leave and joins games

```
Map(1) {
  'empty-owl-83' => {
    clientIds: [ 'antondilon@gmail.com' ],
    round: 0,
    problemsPlayed: []
  }
}
Map(1) {
  'empty-owl-83' => {
    clientIds: [ 'antondilon@gmail.com', 'antondilon2@gmail.com' ],
    round: 0,
    problemsPlayed: []
  }
}
Map(2) {
  'empty-owl-83' => {
    clientIds: [ 'antondilon2@gmail.com' ],
    round: 0,
    problemsPlayed: []
  },
  'average-eagle-40' => {
    clientIds: [ 'antondilon@gmail.com' ],
    round: 0,
    problemsPlayed: []
  }
}
Map(2) {
  'empty-owl-83' => { clientIds: [], round: 0, problemsPlayed: [] },
  'average-eagle-40' => {
    clientIds: [ 'antondilon@gmail.com', 'antondilon2@gmail.com' ],
    round: 0,
    problemsPlayed: []
  }
}
```

### Before

```
Map(2) {
  'spicy-kangaroo-73' => {
    clientIds: [ 'antondilon@gmail.com', 'antondilon2@gmail.com' ],
    round: 1,
    problemsPlayed: [ '63794a6952d8441c74627f63' ],
    endTime: 1676205690274
  },
  'friendly-lion-69' => {
    clientIds: [ 'antondilon@gmail.com', 'antondilon2@gmail.com' ],
    round: 1,
    problemsPlayed: [ '63794a6952d8441c74627f63' ],
    endTime: 1676205697924
  }
}
```