### PR TITLE
[BE][Leaderboard] Add leaderboard route

### DIFF
--- a/src/backend/src/routes/matchs.js
+++ b/src/backend/src/routes/matchs.js
@@ -21,7 +21,7 @@ router.get('/leaderboard/:top?', async (req, res) => {
   try {
     let top = 100;
     if (req.params.top) {
-      top = parseInt(req.params.top);
+      top = Number(req.params.top);
     }
     const leaderboard = await Matchs.aggregate([
       {

--- a/src/backend/src/routes/matchs.js
+++ b/src/backend/src/routes/matchs.js
@@ -27,16 +27,21 @@ router.get('/leaderboard/:top?', async (req, res) => {
       {
         $group: {
           _id: '$player_id',
-          sum: {
+          rounds: {
             $sum: {
               $toInt: '$rounds_completed',
+            },
+          },
+          wins: {
+            $sum: {
+              $toInt: '$win',
             },
           },
         },
       },
       {
         $sort: {
-          sum: -1,
+          wins: -1,
         },
       },
       { $limit: top },

--- a/src/backend/src/routes/matchs.js
+++ b/src/backend/src/routes/matchs.js
@@ -17,4 +17,36 @@ router.get('/user/:_id', async (req, res) => {
   }
 });
 
+router.get('/leaderboard/:top?', async (req, res) => {
+  try {
+    let top = 100;
+    if (req.params.top) {
+      top = parseInt(req.params.top);
+    }
+    const matchs = await Matchs.aggregate([
+      {
+        $group: {
+          _id: '$player_id',
+          sum: {
+            $sum: {
+              $toInt: '$rounds_completed',
+            },
+          },
+        },
+      },
+      {
+        $sort: {
+          sum: -1,
+        },
+      },
+      { $limit: top },
+    ]);
+    res.status(200).send(matchs);
+  } catch (e) {
+    res.status(500).send({
+      message: e,
+    });
+  }
+});
+
 export default router;

--- a/src/backend/src/routes/matchs.js
+++ b/src/backend/src/routes/matchs.js
@@ -23,7 +23,7 @@ router.get('/leaderboard/:top?', async (req, res) => {
     if (req.params.top) {
       top = parseInt(req.params.top);
     }
-    const matchs = await Matchs.aggregate([
+    const leaderboard = await Matchs.aggregate([
       {
         $group: {
           _id: '$player_id',
@@ -41,7 +41,7 @@ router.get('/leaderboard/:top?', async (req, res) => {
       },
       { $limit: top },
     ]);
-    res.status(200).send(matchs);
+    res.status(200).send(leaderboard);
   } catch (e) {
     res.status(500).send({
       message: e,


### PR DESCRIPTION
### Demo

- matches/leaderboard/?top
- Allows to retrieve top number of players as a route param, default 100
- Ranked by winnings with rounds completed included

### Demo

```
// http://localhost:3000/matchs/leaderboard/

[
  {
    "_id": "antondilon@gmail.com",
    "rounds": 49,
    "wins": 6
  },
  {
    "_id": "codechampnmac@gmail.com",
    "rounds": 4,
    "wins": 4
  },
  {
    "_id": "tamasfun@gmail.com",
    "rounds": 3,
    "wins": 3
  },
  {
    "_id": "youssef.rizkalla1@gmail.com",
    "rounds": 3,
    "wins": 3
  },
  {
    "_id": "antondilon2@gmail.com",
    "rounds": 1,
    "wins": 1
  },
  {
    "_id": "yduck2000@gmail.com",
    "rounds": 1,
    "wins": 1
  },
  {
    "_id": "dipesube@gmail.com",
    "rounds": 4,
    "wins": 0
  },
  {
    "_id": "dipesu12@gmail.com",
    "rounds": 5,
    "wins": 0
  }
]
```

Top n
```
// http://localhost:3000/matchs/leaderboard/3

[
  {
    "_id": "antondilon@gmail.com",
    "rounds": 49,
    "wins": 6
  },
  {
    "_id": "codechampnmac@gmail.com",
    "rounds": 4,
    "wins": 4
  },
  {
    "_id": "tamasfun@gmail.com",
    "rounds": 3,
    "wins": 3
  }
]
```

