### PR TITLE
[FE][BE][Profile] Populate and display problem in profile match history

### DIFF
--- a/src/backend/src/routes/matchs.js
+++ b/src/backend/src/routes/matchs.js
@@ -8,7 +8,11 @@ router.get('/user/:_id', async (req, res) => {
     const filter = {
       player_id: req.params._id,
     };
-    const matchs = await Matchs.find(filter);
+    const matchs = await Matchs.find(filter).populate({
+      path: 'problems',
+      model: 'problems',
+      select: { name: 1, description: 1, difficulty: 1 },
+    });
     res.status(200).send(matchs);
   } catch (e) {
     res.status(500).send({

--- a/src/frontend/src/app/myprofile/myprofile.component.html
+++ b/src/frontend/src/app/myprofile/myprofile.component.html
@@ -18,22 +18,18 @@
   </div>
 
   <div class="right-half">
-    <mat-card
-      class="match-history-card"
-      *ngFor="let match of userStats; let i = index"
-    >
-      <h1
-        class="history-text"
-        [ngClass]="{ green: match.win, red: !match.win }"
-      >
-        {{ match.win ? 'Victory' : 'Defeat&nbsp;' }}
-      </h1>
-      <h1 class="history-text1">
-        {{ match.problems }}
-      </h1>
-    </mat-card>
-    <h1 *ngIf="userStats?.length == 0" class="history-text2">
-      Play a match to see your match history!
-    </h1>
+    <mat-expansion-panel *ngFor="let match of userStats" class="match-history-card">
+      <mat-expansion-panel-header style="padding: 40px;">
+        <mat-panel-title>
+          <h1 class=" history-text" [ngClass]="{ green: match.win, red: !match.win }">
+            {{ match.win ? 'Victory' : 'Defeat&nbsp;' }}
+          </h1>
+        </mat-panel-title>
+        <mat-panel-description class="history-text1">
+          {{ match.problems.length }} problem(s) attempted
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <p *ngFor="let problem of match.problems">{{problem.name}} - {{problem.difficulty}}</p>
+    </mat-expansion-panel>
   </div>
 </section>

--- a/src/frontend/src/app/myprofile/myprofile.component.html
+++ b/src/frontend/src/app/myprofile/myprofile.component.html
@@ -18,10 +18,16 @@
   </div>
 
   <div class="right-half">
-    <mat-expansion-panel *ngFor="let match of userStats" class="match-history-card">
-      <mat-expansion-panel-header style="padding: 40px;">
+    <mat-expansion-panel
+      *ngFor="let match of userStats"
+      class="match-history-card"
+    >
+      <mat-expansion-panel-header style="padding: 40px">
         <mat-panel-title>
-          <h1 class=" history-text" [ngClass]="{ green: match.win, red: !match.win }">
+          <h1
+            class="history-text"
+            [ngClass]="{ green: match.win, red: !match.win }"
+          >
             {{ match.win ? 'Victory' : 'Defeat&nbsp;' }}
           </h1>
         </mat-panel-title>
@@ -29,7 +35,9 @@
           {{ match.problems.length }} problem(s) attempted
         </mat-panel-description>
       </mat-expansion-panel-header>
-      <p *ngFor="let problem of match.problems">{{problem.name}} - {{problem.difficulty}}</p>
+      <p *ngFor="let problem of match.problems">
+        {{ problem.name }} - {{ problem.difficulty }}
+      </p>
     </mat-expansion-panel>
   </div>
 </section>

--- a/src/frontend/src/app/myprofile/myprofile.component.scss
+++ b/src/frontend/src/app/myprofile/myprofile.component.scss
@@ -131,17 +131,12 @@
 }
 
 .match-history-card {
-  display: flex;
-  width: 100%;
-  height: 100px;
-  margin-top: 10px;
   margin-bottom: 10px;
   border-radius: 5px;
   background: rgba(255, 255, 255, 0.05);
   border: 2px solid #ffffff;
   color: white;
-  float: left;
-  align-items: center;
+
 }
 
 .green {
@@ -153,23 +148,20 @@
   color: rgb(253, 71, 71);
   font-weight: 700;
 }
+
 .history-text {
   font-family: 'Mulish';
   padding-left: 2%;
   padding-top: 1%;
   font-size: 30px;
+  padding-top: 10px;
 }
+
 .history-text1 {
   font-family: 'Mulish';
   padding-left: 12%;
   padding-bottom: 1%;
   padding-top: 1%;
-  font-size: 30px;
-}
-.history-text2 {
-  font-family: 'Mulish';
-  padding-left: 25%;
-  padding-top: 1%;
-  font-size: 30px;
+  font-size: 25px;
   color: white;
 }

--- a/src/frontend/src/app/myprofile/myprofile.component.scss
+++ b/src/frontend/src/app/myprofile/myprofile.component.scss
@@ -39,6 +39,7 @@
   width: 45.22px;
   height: 45.22px;
   float: left;
+  margin-top: 20px;
 }
 
 .player-name {
@@ -46,7 +47,7 @@
   font-family: 'Mulish';
   float: right;
   font-size: 40px;
-  margin-top: 5px;
+  margin-top: 20px;
 }
 
 /* Pattern styles */
@@ -57,7 +58,7 @@
   margin-top: 100px;
   margin-left: 2%;
   margin-right: 2%;
-  grid-template-columns: 35% 55%;
+  grid-template-columns: 35% 58%;
   column-gap: 2%;
 }
 
@@ -136,7 +137,6 @@
   background: rgba(255, 255, 255, 0.05);
   border: 2px solid #ffffff;
   color: white;
-
 }
 
 .green {

--- a/src/frontend/src/app/services/profile/profile.service.ts
+++ b/src/frontend/src/app/services/profile/profile.service.ts
@@ -10,7 +10,7 @@ export class ProfileService {
   url = environment.apiUrl;
   id = '';
   constructor(private http: HttpClient, private authService: AuthService) {
-    this.id = authService.getPlayerData().id;
+    this.id = authService.getPlayerData().email;
   }
 
   getUserStats() {

--- a/src/frontend/src/app/services/profile/profile.service.ts
+++ b/src/frontend/src/app/services/profile/profile.service.ts
@@ -18,10 +18,17 @@ export class ProfileService {
   }
 }
 
+interface ProblemInStats {
+  _id: string;
+  name: string;
+  description: string;
+  difficulty: string;
+}
+
 export interface Stats {
   game_id: string;
   player_id: string;
   win: Boolean;
   rounds_completed: Number;
-  problems: string[];
+  problems: ProblemInStats[];
 }


### PR DESCRIPTION
### Changes

- Fix bug in user stats call, using id instead of email (id doesn't exist)
- Populates data for stats
- New display of history

### Demo

<img width="1920" alt="Screenshot 2023-02-12 at 8 07 47 PM" src="https://user-images.githubusercontent.com/39676112/218349351-078faa2c-278f-4933-b2fd-794d059bb968.png">


```
{
    "_id": "63e8c16ddb1adfe67bf5ad63",
    "game_id": "fat-panda-31",
    "player_id": "antondilon@gmail.com",
    "win": true,
    "rounds_completed": 5,
    "problems": [
      {
        "_id": "63794a6952d8441c74627f63",
        "name": "Hello World",
        "description": "Print out the message `Hello, World!` to standard output.",
        "difficulty": "Easy"
      }
    ],
    "__v": 0
  },
```

### TODO

Update problem list display
