### PR TITLE
Store a unique solution & format for each language

### DIFF
--- a/src/frontend/src/app/problem/code-editor/code-editor.component.html
+++ b/src/frontend/src/app/problem/code-editor/code-editor.component.html
@@ -1,5 +1,8 @@
 <mat-form-field class="lang-dropdown" appearance="outline">
-  <mat-select [(value)]="selectedLanguage">
+  <mat-select
+    (selectionChange)="onLanguageChanged($event)"
+    [(value)]="selectedLanguage"
+  >
     <mat-option *ngFor="let language of dropdownLanguages" [value]="language">
       {{ language.displayName }}
     </mat-option>

--- a/src/frontend/src/app/problem/submission-list/submission-list.component.html
+++ b/src/frontend/src/app/problem/submission-list/submission-list.component.html
@@ -27,6 +27,6 @@
     <p *ngIf="submission.additionalInfo" class="code">
       {{ submission.additionalInfo }}
     </p>
-    <p class="code">{{ getFormattedCode(submission) }}</p>
+    <p class="code">{{ submission.code }}</p>
   </mat-expansion-panel>
 </div>

--- a/src/frontend/src/app/problem/submission-list/submission-list.component.ts
+++ b/src/frontend/src/app/problem/submission-list/submission-list.component.ts
@@ -15,12 +15,5 @@ export class SubmissionListComponent {
     return submissionResult.correct ? 'success-text' : 'wrong-text';
   }
 
-  getFormattedCode(submissionResult: SubmissionResult) {
-    return prettier.format(submissionResult.code, {
-      parser: 'babel',
-      plugins: [tsParser],
-    });
-  }
-
   constructor() {}
 }

--- a/src/frontend/src/app/types/Language.ts
+++ b/src/frontend/src/app/types/Language.ts
@@ -1,14 +1,11 @@
-import { CodeModel } from '@ngstack/code-editor';
 import * as prettier from 'prettier/standalone';
 import * as tsParser from 'prettier/parser-babel';
+
 export interface Language {
   displayName: string;
   extension: string;
   templateCode: string;
-  // The displayed code will not be reset unless it's completely re-assigned.
-  // So we need to reset the value after formatting by stringifying and parsing the object.
-  // https://github.com/ngstack/code-editor/issues/1030
-  format(codeModel: CodeModel): CodeModel;
+  format(code: string): string;
 }
 
 const javaScript: Language = {
@@ -16,13 +13,11 @@ const javaScript: Language = {
   extension: 'mjs',
   templateCode:
     "import readline from 'readline'; const stdin = readline.createInterface({ input: process.stdin, output: process.stdout, }); stdin.question('', (input) => { console.log(\"Your answer here...\"); stdin.close(); });",
-  format: (codeModel) => {
-    codeModel.value = prettier.format(codeModel.value, {
+  format: (code) =>
+    prettier.format(code, {
       parser: 'babel',
       plugins: [tsParser],
-    });
-    return JSON.parse(JSON.stringify(codeModel));
-  },
+    }),
 };
 
 const python: Language = {
@@ -30,7 +25,7 @@ const python: Language = {
   extension: 'py',
   templateCode: `inp = input()
 print('Your answer here...')`,
-  format: (codeModel) => JSON.parse(JSON.stringify(codeModel)),
+  format: (code) => code,
 };
 
 export const languages = { javaScript, python };

--- a/src/frontend/src/app/types/Language.ts
+++ b/src/frontend/src/app/types/Language.ts
@@ -1,9 +1,36 @@
+import { CodeModel } from '@ngstack/code-editor';
+import * as prettier from 'prettier/standalone';
+import * as tsParser from 'prettier/parser-babel';
 export interface Language {
   displayName: string;
   extension: string;
+  templateCode: string;
+  // The displayed code will not be reset unless it's completely re-assigned.
+  // So we need to reset the value after formatting by stringifying and parsing the object.
+  // https://github.com/ngstack/code-editor/issues/1030
+  format(codeModel: CodeModel): CodeModel;
 }
 
-const javaScript: Language = { displayName: 'JavaScript', extension: 'mjs' };
-const python: Language = { displayName: 'Python', extension: 'py' };
+const javaScript: Language = {
+  displayName: 'JavaScript',
+  extension: 'mjs',
+  templateCode:
+    "import readline from 'readline'; const stdin = readline.createInterface({ input: process.stdin, output: process.stdout, }); stdin.question('', (input) => { console.log(\"Your answer here...\"); stdin.close(); });",
+  format: (codeModel) => {
+    codeModel.value = prettier.format(codeModel.value, {
+      parser: 'babel',
+      plugins: [tsParser],
+    });
+    return JSON.parse(JSON.stringify(codeModel));
+  },
+};
+
+const python: Language = {
+  displayName: 'Python',
+  extension: 'py',
+  templateCode: `inp = input()
+print('Your answer here...')`,
+  format: (codeModel) => JSON.parse(JSON.stringify(codeModel)),
+};
 
 export const languages = { javaScript, python };


### PR DESCRIPTION
- Added a formatter field in Language.ts
- Added template code for Python
- Python doesn't have a specific formatter for now, but the default highlighting works well enough (see image)
- The problem page will store a solution for each language, allowing the user to swap between languages without losing their previous solutions
- Removed formatting from submission list since the solution will already be formatted before arriving there now.

![image](https://user-images.githubusercontent.com/32617102/227376660-822f3cb4-c8a7-4dac-8d16-0e66bb034e22.png)

Closes #147 
